### PR TITLE
woflictl-lint: Set --log-level info

### DIFF
--- a/wolfictl-lint/action.yaml
+++ b/wolfictl-lint/action.yaml
@@ -24,7 +24,7 @@ runs:
       uses: docker://ghcr.io/wolfi-dev/sdk:latest@sha256:85395b926c5836d442c7ef0b44f8cf8700050b991b22aa61a324d8cace2a4988
       with:
         entrypoint: wolfictl
-        args: lint --skip-rule no-makefile-entry-for-package
+        args: --log-level info lint --skip-rule no-makefile-entry-for-package
 
     - name: Enforce YAML formatting
       if: ${{ inputs.run_wolfictl_lint_yam == 'true' }}


### PR DESCRIPTION
By default wolfictl lint isn't printing any information about what failed.  I thought the action used to print what failed but since log-level applies to every wolfi sub command changing it here instead of the wolfictl default seems to make more sense.

```
wolfictl lint ./bad-license.yaml
2025/03/26 13:42:46 ERRO linting failed
```

```
wolfictl --log-level info lint ./bad-license.yaml
2025/03/26 13:50:13 INFO Package: bad-license: [valid-update-schedule]: unsupported period: hourly (ERROR)
2025/03/26 13:50:13 ERRO linting failed
```