### PR TITLE
update ci job with best practices

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -7,11 +7,16 @@ on:
   pull_request:
     branches: [ 'main', 'release-*' ]
 
+permissions: {}
+
 jobs:
 
   action-lint:
     name: Action lint
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
       - name: Harden Runner
@@ -21,6 +26,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Find yamls
         id: get_yamls


### PR DESCRIPTION
to close a security warning