### PR TITLE
Revert "Disable wolfictl-lint:lint yam check for now until we can re-align the yam version in wolfictl. (#467)"

### DIFF
--- a/wolfictl-lint/action.yaml
+++ b/wolfictl-lint/action.yaml
@@ -25,3 +25,11 @@ runs:
       with:
         entrypoint: wolfictl
         args: --log-level info lint --skip-rule no-makefile-entry-for-package
+
+    - name: Enforce YAML formatting
+      if: ${{ inputs.run_wolfictl_lint_yam == 'true' }}
+      id: lint-yaml
+      uses: docker://ghcr.io/wolfi-dev/sdk:latest@sha256:aa5c848fe9c8397fad36499c289bab7e225dde9d68b2df386496aef5652b0c6e
+      with:
+        entrypoint: wolfictl
+        args: lint yam


### PR DESCRIPTION


We've instead re-yamified all files w/ the updated yam, so we should be albe to re-enable this check now.

This reverts commit 62ad04c597c9a889975144ef1508f4ce62361296.