### PR TITLE
Really disable wolfictl-lint:lint yamcheck

### DIFF
--- a/wolfictl-lint/action.yaml
+++ b/wolfictl-lint/action.yaml
@@ -25,11 +25,3 @@ runs:
       with:
         entrypoint: wolfictl
         args: --log-level info lint --skip-rule no-makefile-entry-for-package
-
-    - name: Enforce YAML formatting
-      if: ${{ inputs.run_wolfictl_lint_yam == 'true' }}
-      id: lint-yaml
-      uses: docker://ghcr.io/wolfi-dev/sdk:latest@sha256:aa5c848fe9c8397fad36499c289bab7e225dde9d68b2df386496aef5652b0c6e
-      with:
-        entrypoint: wolfictl
-        args: lint yam


### PR DESCRIPTION
We already run `yam` in CI via `lint.sh`, we don't need to do it a second time. This test has no way to exclude certain files, like .pre-commit-config.yaml, while `lint.sh` only runs `yam` on the melange yaml files by default.