### PR TITLE
fix(ci): GitHub Actions security hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3

--- a/.github/workflows/.ci-build.yml
+++ b/.github/workflows/.ci-build.yml
@@ -90,6 +90,8 @@ jobs:
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: ${{ inputs.enterprise == 'false' }}
+        with:
+          persist-credentials: false
 
 
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
@@ -102,6 +104,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: ${{ inputs.enterprise == 'true' }}
         with:
+          persist-credentials: false
           ref: ${{ inputs.checkout_sha }}
           submodules: "recursive"
           token: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/.ci-build.yml
+++ b/.github/workflows/.ci-build.yml
@@ -127,19 +127,26 @@ jobs:
 
       - name: 'Generate local signing key'
         shell: bash
+        env:
+          MELANGE_KEYNAME: ${{ inputs.melange_keyname }}
         run: |
-          make MELANGE="melange" ${{ inputs.melange_keyname }}
+          make MELANGE="melange" "$MELANGE_KEYNAME"
 
       - name: 'touch signing key'
         shell: bash
         if: ${{ inputs.enterprise == 'true' }}
+        env:
+          MELANGE_KEYNAME: ${{ inputs.melange_keyname }}
         run: |
           # Touch it with the epoch date to convince `make` that we don't need to
           # rebuild the targets that depend on this (all)
-          touch -d @0 ${{ inputs.melange_keyname }}
+          touch -d @0 "$MELANGE_KEYNAME"
 
       - name: 'Prepare package repository'
         if: ${{ inputs.enterprise == 'true' }}
+        env:
+          INPUTS_ARCH: ${{ inputs.arch }}
+          INPUTS_ENTERPRISE_BUCKET_NAME: ${{ inputs.enterprise_bucket_name }}
         run: |
           # yay wolfi!
           apk add gcsfuse
@@ -148,24 +155,26 @@ jobs:
           # cheerful way to recreate the make targets (class A HEADs) locally
           # without syncing the whole bucket (class A+B).
           mkdir -p /gcsfuse/enterprise-registry
-          gcsfuse -o ro --implicit-dirs --only-dir os ${{ inputs.enterprise_bucket_name }} /gcsfuse/enterprise-registry
+          gcsfuse -o ro --implicit-dirs --only-dir os "$INPUTS_ENTERPRISE_BUCKET_NAME" /gcsfuse/enterprise-registry
 
-          mkdir -p ./packages/${{ inputs.arch }}
+          mkdir -p "./packages/${INPUTS_ARCH}"
           # Symlink the gcsfuse mount to ./packages/ and the pub key to workaround the Makefile CWD assumptions
-          ln -s /gcsfuse/enterprise-registry/${{ inputs.arch }}/*.apk ./packages/${{ inputs.arch }}/
+          ln -s /gcsfuse/enterprise-registry/"${INPUTS_ARCH}"/*.apk "./packages/${INPUTS_ARCH}/"
 
           # Make a copy of the APKINDEX.* since we'll need to write to it on package builds
-          cp /gcsfuse/enterprise-registry/${{ inputs.arch }}/APKINDEX.* ./packages/${{ inputs.arch }}/
+          cp /gcsfuse/enterprise-registry/"${INPUTS_ARCH}"/APKINDEX.* "./packages/${INPUTS_ARCH}/"
 
           # Ensure the file exists at all, so we can upload it as an artifact.
           touch packages.log
 
       - name: 'Build Wolfi'
         if: ${{ inputs.enterprise == 'false' }}
+        env:
+          INPUTS_PACKAGES: ${{ inputs.packages }}
         run: |
           # Setup the melange cache dir on the host so we can use that in subsequent builds
           mkdir ../.melangecache
-          IFS=',' read -ra packages <<< "${{ inputs.packages }}"
+          IFS=',' read -ra packages <<< "$INPUTS_PACKAGES"
           for package in "${packages[@]}"; do
             make MELANGE_EXTRA_OPTS="--create-build-log --cache-dir=$(pwd)/../.melangecache" REPO="$GITHUB_WORKSPACE/packages" package/"$package" -j1
             make REPO="$GITHUB_WORKSPACE/packages" test/"$package" -j1
@@ -173,10 +182,12 @@ jobs:
 
       - name: 'Build Enterprise Packages'
         if: ${{ inputs.enterprise == 'true' }}
+        env:
+          INPUTS_PACKAGES: ${{ inputs.packages }}
         run: |
           # Setup the melange cache dir on the host so we can use that in subsequent builds
           mkdir ../.melangecache
-          IFS=',' read -ra packages <<< "${{ inputs.packages }}"
+          IFS=',' read -ra packages <<< "$INPUTS_PACKAGES"
           for package in "${packages[@]}"; do
             make MELANGE_EXTRA_OPTS="--create-build-log --cache-dir=$(pwd)/../.melangecache --keyring-append=/gcsfuse/enterprise-registry/chainguard-enterprise.rsa.pub" REPO="$GITHUB_WORKSPACE/packages" package/"$package" -j1
             make REPO="$GITHUB_WORKSPACE/packages" MELANGE_EXTRA_OPTS="--keyring-append=/gcsfuse/enterprise-registry/chainguard-enterprise.rsa.pub" test/"$package" -j1
@@ -205,6 +216,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: "Check that packages can be installed with apk add"
+        env:
+          FILES_TO_UPLOAD: ${{ steps.list_built_packages.outputs.files_to_upload }}
         run: |
           # Create a fake linux fs under /tmp/emptyroot to pass to `apk --root`.
           mkdir -p /tmp/emptyroot/etc/apk
@@ -218,7 +231,7 @@ jobs:
           apk update --root /tmp/emptyroot
 
           # Find .apk files and add them to the string
-          IFS=',' read -ra files <<< "${{ steps.list_built_packages.outputs.files_to_upload }}"
+          IFS=',' read -ra files <<< "$FILES_TO_UPLOAD"
           for f in "${files[@]}"; do
               tar -Oxf "$f" .PKGINFO
               apk add --root /tmp/emptyroot --repository ./packages --allow-untrusted --simulate "$f"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -7,3 +7,8 @@ rules:
   dependabot-cooldown:
     config:
       days: 3
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  concurrency-limits:
+    disable: true

--- a/build-and-publish-osv/action.yaml
+++ b/build-and-publish-osv/action.yaml
@@ -74,11 +74,13 @@ runs:
     - name: 'Upload the security database to a bucket'
       run: |
         # Don't cache the security.json.
-        # ENABLE_ACL_PUBLIC_READ is intentionally unquoted: it is an optional
-        # flag that is either empty or "--canned-acl=publicRead" and must
-        # word-split (or vanish when empty).
+        # ENABLE_ACL_PUBLIC_READ is an optional flag: empty, or a single token
+        # like "--canned-acl=publicRead". Build it as an array so it is passed
+        # as one quoted argument when set and omitted entirely when empty.
+        acl_args=()
+        [ -n "$ENABLE_ACL_PUBLIC_READ" ] && acl_args=("$ENABLE_ACL_PUBLIC_READ")
         gcloud --quiet alpha storage cp \
-            $ENABLE_ACL_PUBLIC_READ --cache-control=no-store \
+            "${acl_args[@]}" --cache-control=no-store \
             './osv/**' \
             "gs://${GCS_APK_BUCKET_NAME}/${GCS_APK_DIRECTORY_NAME}/osv/"
       shell: bash

--- a/build-and-publish-osv/action.yaml
+++ b/build-and-publish-osv/action.yaml
@@ -74,11 +74,15 @@ runs:
     - name: 'Upload the security database to a bucket'
       run: |
         # Don't cache the security.json.
+        # ENABLE_ACL_PUBLIC_READ is intentionally unquoted: it is an optional
+        # flag that is either empty or "--canned-acl=publicRead" and must
+        # word-split (or vanish when empty).
         gcloud --quiet alpha storage cp \
-            ${{ inputs.enable_acl_public_read }} --cache-control=no-store \
+            $ENABLE_ACL_PUBLIC_READ --cache-control=no-store \
             './osv/**' \
-            gs://${{ env.GCS_APK_BUCKET_NAME }}/${{ env.GCS_APK_DIRECTORY_NAME }}/osv/
+            "gs://${GCS_APK_BUCKET_NAME}/${GCS_APK_DIRECTORY_NAME}/osv/"
       shell: bash
       env:
+        ENABLE_ACL_PUBLIC_READ: ${{ inputs.enable_acl_public_read }}
         GCS_APK_BUCKET_NAME: ${{ inputs.gcs_apk_bucket_name }}
         GCS_APK_DIRECTORY_NAME: ${{ inputs.gcs_apk_directory_name}}

--- a/build-and-publish-secdb/action.yaml
+++ b/build-and-publish-secdb/action.yaml
@@ -69,8 +69,15 @@ runs:
     - name: 'Upload the security database to a bucket'
       run: |
         # Don't cache the security.json.
+        # ENABLE_ACL_PUBLIC_READ is intentionally unquoted: it is an optional
+        # flag that is either empty or "--canned-acl=publicRead" and must
+        # word-split (or vanish when empty).
         gcloud --quiet alpha storage cp \
-            ${{ inputs.enable_acl_public_read }} --cache-control=no-store \
+            $ENABLE_ACL_PUBLIC_READ --cache-control=no-store \
             ./security.json \
-            gs://${{ inputs.gcs_apk_bucket_name }}/${{ inputs.gcs_apk_directory_name}}/
+            "gs://${GCS_APK_BUCKET_NAME}/${GCS_APK_DIRECTORY_NAME}/"
       shell: bash
+      env:
+        ENABLE_ACL_PUBLIC_READ: ${{ inputs.enable_acl_public_read }}
+        GCS_APK_BUCKET_NAME: ${{ inputs.gcs_apk_bucket_name }}
+        GCS_APK_DIRECTORY_NAME: ${{ inputs.gcs_apk_directory_name}}

--- a/build-and-publish-secdb/action.yaml
+++ b/build-and-publish-secdb/action.yaml
@@ -69,11 +69,13 @@ runs:
     - name: 'Upload the security database to a bucket'
       run: |
         # Don't cache the security.json.
-        # ENABLE_ACL_PUBLIC_READ is intentionally unquoted: it is an optional
-        # flag that is either empty or "--canned-acl=publicRead" and must
-        # word-split (or vanish when empty).
+        # ENABLE_ACL_PUBLIC_READ is an optional flag: empty, or a single token
+        # like "--canned-acl=publicRead". Build it as an array so it is passed
+        # as one quoted argument when set and omitted entirely when empty.
+        acl_args=()
+        [ -n "$ENABLE_ACL_PUBLIC_READ" ] && acl_args=("$ENABLE_ACL_PUBLIC_READ")
         gcloud --quiet alpha storage cp \
-            $ENABLE_ACL_PUBLIC_READ --cache-control=no-store \
+            "${acl_args[@]}" --cache-control=no-store \
             ./security.json \
             "gs://${GCS_APK_BUCKET_NAME}/${GCS_APK_DIRECTORY_NAME}/"
       shell: bash

--- a/build-and-publish-yaml/action.yaml
+++ b/build-and-publish-yaml/action.yaml
@@ -67,5 +67,8 @@ runs:
         gcloud --quiet alpha storage cp \
             --cache-control=no-store \
             ./advisories.yaml \
-            gs://${{ inputs.gcs_apk_bucket_name }}/${{ inputs.gcs_apk_directory_name}}/
+            "gs://${GCS_APK_BUCKET_NAME}/${GCS_APK_DIRECTORY_NAME}/"
       shell: bash
+      env:
+        GCS_APK_BUCKET_NAME: ${{ inputs.gcs_apk_bucket_name }}
+        GCS_APK_DIRECTORY_NAME: ${{ inputs.gcs_apk_directory_name}}

--- a/install-wolfictl/action.yaml
+++ b/install-wolfictl/action.yaml
@@ -7,7 +7,7 @@ runs:
   using: "composite"
   steps:
     - name: "Install wolfictl onto PATH"
-      run: |
+      run: | # zizmor: ignore[github-env] $TMP is a trusted mktemp -d path (runner-owned, 0700, holds only wolfictl from the pinned sdk image); no attacker-controlled value reaches $GITHUB_PATH
         # Copy wolfictl out of the wolfictl image and onto PATH
         TMP=$(mktemp -d)
         docker run --rm -i -v "$TMP":/out --entrypoint /bin/sh ghcr.io/wolfi-dev/sdk:latest@sha256:bfe574a465dd54bdec763eac1180abd64beadb426638354a6b34c9948c7cde62 -c "cp /usr/bin/wolfictl /out"

--- a/install-wolfictl/action.yaml
+++ b/install-wolfictl/action.yaml
@@ -10,6 +10,6 @@ runs:
       run: |
         # Copy wolfictl out of the wolfictl image and onto PATH
         TMP=$(mktemp -d)
-        docker run --rm -i -v $TMP:/out --entrypoint /bin/sh ghcr.io/wolfi-dev/sdk:latest@sha256:bfe574a465dd54bdec763eac1180abd64beadb426638354a6b34c9948c7cde62 -c "cp /usr/bin/wolfictl /out"
-        echo "$TMP" >> $GITHUB_PATH
+        docker run --rm -i -v "$TMP":/out --entrypoint /bin/sh ghcr.io/wolfi-dev/sdk:latest@sha256:bfe574a465dd54bdec763eac1180abd64beadb426638354a6b34c9948c7cde62 -c "cp /usr/bin/wolfictl /out"
+        echo "$TMP" >> "$GITHUB_PATH"
       shell: bash


### PR DESCRIPTION
This PR applies GitHub Actions hardening fixes, surfaced by static analysis
(zizmor). The repo ships composite actions, so the sweep covered the
`action.yml`/`action.yaml` files as well as `.github/workflows/`.

## What this changes

- **Template-injection fix.** Context expressions interpolated into `run:`
  blocks are moved into `env:` and referenced as quoted shell variables.
- **`persist-credentials: false`** on checkout steps that don't push back.
- **Repo-level zizmor config** disabling cosmetic pedantic-only rules, plus a
  `dependabot-cooldown` threshold.
- **Optional gcloud ACL flag passed as an array** (`build-and-publish-osv`,
  `build-and-publish-secdb`). The `enable_acl_public_read` input is optional —
  empty, or a single token like `--canned-acl=publicRead`. It was interpolated
  unquoted so it would vanish when empty; that's fragile (a quoted-empty value
  would pass a spurious empty argument). Build it as a bash array —
  `"${acl_args[@]}"` expands to zero args when empty and one quoted arg when
  set — which is robust and lint-clean.
- **Harden `install-wolfictl`.** Quote `$TMP` and `$GITHUB_PATH` (both safe
  single-value paths — `$TMP` from `mktemp -d`, `$GITHUB_PATH` the runner sink),
  and annotate the `$GITHUB_PATH` write with a scoped `# zizmor: ignore[github-env]`
  plus rationale: the value written is a trusted `mktemp -d` path holding only
  `wolfictl` from the pinned sdk image, so no attacker-controlled value reaches
  the environment file.

## Test plan

- `zizmor .github/` (plus the composite `action.yml` files) — clean after these
  changes for the auto-fixable rule classes.
- `actionlint` — workflows still parse with no errors.

Refs: PSEC-923